### PR TITLE
Update affixInitialTop on scroll

### DIFF
--- a/src/affix.vue
+++ b/src/affix.vue
@@ -180,6 +180,7 @@ export default {
       this.affixRect = this.$el.getBoundingClientRect();
       this.affixHeight = this.$el.offsetHeight;
       this.relativeElmOffsetTop = this.getOffsetTop(this.relativeElement);
+      this.affixInitialTop = this.getOffsetTop(this.$el);
     },
 
     onScroll() {


### PR DESCRIPTION
If there is a content inited after affix is been inited (for example: ads). And it is located before affix, then affix wouldn't update `affixInitialTop` value and would calculate wrong offsets during scroll events.